### PR TITLE
EmailAPI Validation cleanup + test coverage

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,0 +1,13 @@
+name: Unit Tests
+on: [ pull_request ]
+jobs:
+  jest:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - uses: pnpm/action-setup@v4
+      - name: Test
+        run: pnpm test:unit
+        with:
+          version: 8

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,10 @@
+/** @type {import('ts-jest').JestConfigWithTsJest} **/
+module.exports = {
+  testEnvironment: "node",
+  transform: {
+    "^.+.tsx?$": ["ts-jest",{}],
+  },
+  roots: [
+    "./tests/"
+  ]
+};

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "test:lint": "eslint src --ext .ts",
     "test:prettier": "prettier \"src/**/*.ts\" --list-different",
     "test:spelling": "cspell \"{README.md,.github/*.md,src/**/*.ts}\"",
-    "test:unit": "nyc --silent ava",
+    "test:unit": "jest",
     "check-cli": "run-s test diff-integration-tests check-integration-tests",
     "check-integration-tests": "run-s check-integration-test:*",
     "diff-integration-tests": "mkdir -p diff && rm -rf diff/test && cp -r test diff/test && rm -rf diff/test/test-*/.git && cd diff && git init --quiet && git add -A && git commit --quiet --no-verify --allow-empty -m 'WIP' && echo '\\n\\nCommitted most recent integration test output in the \"diff\" directory. Review the changes with \"cd diff && git diff HEAD\" or your preferred git diff viewer.'",
@@ -46,6 +46,9 @@
     "request": "^2.88.2"
   },
   "devDependencies": {
+    "ts-jest": "^29.2.5",
+    "@types/jest": "^29.5.14",
+    "jest": "^29.7.0",
     "@ava/typescript": "^1.1.1",
     "@istanbuljs/nyc-config-typescript": "^1.0.1",
     "@types/request": "^2.48.12",

--- a/package.json
+++ b/package.json
@@ -46,11 +46,10 @@
     "request": "^2.88.2"
   },
   "devDependencies": {
-    "ts-jest": "^29.2.5",
-    "@types/jest": "^29.5.14",
-    "jest": "^29.7.0",
     "@ava/typescript": "^1.1.1",
     "@istanbuljs/nyc-config-typescript": "^1.0.1",
+    "@types/jest": "^29.5.14",
+    "@types/node": "^22.7.9",
     "@types/request": "^2.48.12",
     "@typescript-eslint/eslint-plugin": "^4.0.1",
     "@typescript-eslint/parser": "^4.0.1",
@@ -64,14 +63,26 @@
     "eslint-plugin-functional": "^3.0.2",
     "eslint-plugin-import": "^2.22.0",
     "gh-pages": "^3.1.0",
+    "jest": "^29.7.0",
     "npm-run-all": "^4.1.5",
     "nyc": "^15.1.0",
     "open-cli": "^6.0.1",
     "prettier": "^2.1.1",
     "standard-version": "^9.0.0",
+    "ts-jest": "^29.2.5",
     "ts-node": "^9.0.0",
     "typedoc": "^0.19.0",
     "typescript": "^4.0.2"
+  },
+  "exports": {
+    ".": {
+      "types": "./build/main/index.js",
+      "default": "./build/main/index.d.ts"
+    },
+    "./*": {
+      "types": "./build/main/*.js",
+      "default": "./build/main/*.d.ts"
+    }
   },
   "files": [
     "build/main",

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -4,7 +4,7 @@ import {
   IssueApiKeyRequest,
   IssueJWTResponse,
 } from '../internal/api';
-import JunoError from './errors';
+import { JunoValidationError } from './errors';
 import { validateString } from './validators';
 
 export class AuthAPI {

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -4,6 +4,8 @@ import {
   IssueApiKeyRequest,
   IssueJWTResponse,
 } from '../internal/api';
+import JunoError from './errors';
+import { validateString } from './validators';
 
 export class AuthAPI {
   private internalApi: AuthApi;
@@ -24,15 +26,12 @@ export class AuthAPI {
     description: string | undefined;
   }): Promise<IssueApiKeyResponse> {
     let { email, password, project, environment, description } = options;
-    if (!email || email.trim().length === 0) {
-      throw new Error('The email must be nonempty');
-    }
-    if (!password || password.trim().length === 0) {
-      throw new Error('The password for the user must be nonempty');
-    }
-    if (!environment || environment.trim().length === 0) {
-      throw new Error('The environment for the user must be nonempty');
-    }
+
+    validateString(email, 'The email must be nonempty');
+
+    validateString(password, 'The password for the user must be nonempty');
+    validateString(environment, 'The environment for the user must be nonempty');
+
     email = email.trim();
     password = password.trim();
     environment = environment.trim();
@@ -57,9 +56,9 @@ export class AuthAPI {
   }
   async revokeKey(options: { apiKey: string }): Promise<any> {
     let { apiKey } = options;
-    if (!apiKey || apiKey.trim().length === 0) {
-      throw new Error('The authorization token must be nonempty');
-    }
+
+    validateString(apiKey, 'The authorization token must be nonempty');
+
     apiKey = apiKey.trim();
     try {
       const result = await this.internalApi.authControllerDeleteApiKey(apiKey);

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -4,7 +4,6 @@ import {
   IssueApiKeyRequest,
   IssueJWTResponse,
 } from '../internal/api';
-import { JunoValidationError } from './errors';
 import { validateString } from './validators';
 
 export class AuthAPI {
@@ -35,7 +34,7 @@ export class AuthAPI {
     email = email.trim();
     password = password.trim();
     environment = environment.trim();
-    description = description.trim();
+    description = description?.trim();
     try {
       const issueApiKeyRequest: IssueApiKeyRequest = {
         description,

--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -12,7 +12,7 @@ import {
   RegisterDomainResponse,
 } from '../internal/api';
 import { AuthAPI } from './auth';
-import JunoError from './errors';
+import { JunoValidationError } from './errors';
 import { validateEmailContent, validateEmailRecipient, validateEmailSender, validateString } from './validators';
 
 export class EmailAPI {
@@ -33,13 +33,18 @@ export class EmailAPI {
   }): Promise<SendEmailResponse> {
     const { recipients, cc, bcc, sender, contents } = options;
     if (!recipients || !sender || !contents) {
-      throw new JunoError(
+      throw new JunoValidationError(
         'Parameter recipients or sender or content cannot be null'
       );
     }
-    if (recipients.length === 0 || contents.length === 0) {
-      throw new JunoError(
-        'Parameter recipients or content cannot be an empty array'
+
+    if (recipients.length === 0 && cc?.length === 0 && bcc?.length === 0) {
+      throw new JunoValidationError("Email request must have at least one recipient, cc, or bcc.")
+    }
+
+    if (contents.length === 0) {
+      throw new JunoValidationError(
+        'Parameter contents cannot be an empty array'
       );
     }
     recipients.forEach((recipient) => validateEmailRecipient(recipient));
@@ -65,7 +70,7 @@ export class EmailAPI {
       );
       return result.body;
     } catch (e) {
-      throw new JunoError(e);
+      throw e;
     }
   }
   async registerSenderAddress(options: {
@@ -94,7 +99,7 @@ export class EmailAPI {
         );
       return result.body;
     } catch (e) {
-      throw new JunoError(e);
+      throw e;
     }
   }
   async registerDomain(options: {
@@ -120,7 +125,7 @@ export class EmailAPI {
       );
       return result.body;
     } catch (e) {
-      throw new JunoError(e);
+      throw e;
     }
   }
   async verifyDomain(options: {
@@ -144,7 +149,7 @@ export class EmailAPI {
       );
       return result.body;
     } catch (e) {
-      throw new JunoError(e);
+      throw e;
     }
   }
 }

--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -38,7 +38,7 @@ export class EmailAPI {
       );
     }
 
-    if (recipients.length === 0 && cc?.length === 0 && bcc?.length === 0) {
+    if ((!recipients || recipients.length === 0) && (!cc || cc.length === 0) && (!bcc || bcc.length === 0)) {
       throw new JunoValidationError("Email request must have at least one recipient, cc, or bcc.")
     }
 
@@ -81,6 +81,7 @@ export class EmailAPI {
     let { email, name, replyTo } = options;
 
     validateString(email, 'Email cannot be null or empty string');
+    validateString(name, 'Name cannot be null or empty string');
 
     try {
       const registerEmailModel = new RegisterEmailModel();

--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -12,6 +12,8 @@ import {
   RegisterDomainResponse,
 } from '../internal/api';
 import { AuthAPI } from './auth';
+import JunoError from './errors';
+import { validateEmailContent, validateEmailRecipient, validateEmailSender, validateString } from './validators';
 
 export class EmailAPI {
   private internalApi: EmailApi;
@@ -31,12 +33,12 @@ export class EmailAPI {
   }): Promise<SendEmailResponse> {
     const { recipients, cc, bcc, sender, contents } = options;
     if (!recipients || !sender || !contents) {
-      throw new Error(
+      throw new JunoError(
         'Parameter recipients or sender or content cannot be null'
       );
     }
     if (recipients.length === 0 || contents.length === 0) {
-      throw new Error(
+      throw new JunoError(
         'Parameter recipients or content cannot be an empty array'
       );
     }
@@ -63,7 +65,7 @@ export class EmailAPI {
       );
       return result.body;
     } catch (e) {
-      throw new Error(e);
+      throw new JunoError(e);
     }
   }
   async registerSenderAddress(options: {
@@ -72,9 +74,9 @@ export class EmailAPI {
     replyTo: string | undefined;
   }): Promise<RegisterEmailResponse> {
     let { email, name, replyTo } = options;
-    if (!email || email.trim().length === 0) {
-      throw new Error('Email cannot be null or empty string');
-    }
+
+    validateString(email, 'Email cannot be null or empty string');
+
     try {
       const registerEmailModel = new RegisterEmailModel();
       registerEmailModel.email = email;
@@ -92,7 +94,7 @@ export class EmailAPI {
         );
       return result.body;
     } catch (e) {
-      throw new Error(e);
+      throw new JunoError(e);
     }
   }
   async registerDomain(options: {
@@ -100,9 +102,8 @@ export class EmailAPI {
     subdomain: string | undefined;
   }): Promise<RegisterDomainResponse> {
     const { domain, subdomain } = options;
-    if (!domain || domain.trim().length === 0) {
-      throw new Error('Domain cannot be null or empty string');
-    }
+
+    validateString(domain, 'Domain cannot be null or empty string');
 
     try {
       const registerDomainModel = new RegisterDomainModel();
@@ -119,16 +120,15 @@ export class EmailAPI {
       );
       return result.body;
     } catch (e) {
-      throw new Error(e);
+      throw new JunoError(e);
     }
   }
   async verifyDomain(options: {
     domain: string;
   }): Promise<RegisterDomainResponse> {
     const { domain } = options;
-    if (!domain || domain.trim().length === 0) {
-      throw new Error('Domain cannot be null or empty string');
-    }
+
+    validateString(domain, 'Domain cannot be null or empty string');
 
     try {
       const verifyDomainModel = new VerifyDomainModel();
@@ -144,43 +144,8 @@ export class EmailAPI {
       );
       return result.body;
     } catch (e) {
-      throw new Error(e);
+      throw new JunoError(e);
     }
   }
 }
 
-const validateEmailRecipient = (recipient: EmailRecipient) => {
-  if (!recipient) {
-    throw new Error('Recipient cannot be null');
-  }
-  if (!recipient.email || recipient.email.trim().length === 0) {
-    throw new Error('Recipient email cannot be null or empty string');
-  }
-  if (!recipient.name && recipient.name.trim().length === 0) {
-    throw new Error('Recipient name cannot be empty string');
-  }
-};
-
-const validateEmailSender = (sender: EmailSender) => {
-  if (!sender) {
-    throw new Error('Sender cannot be null');
-  }
-  if (!sender.email || sender.email.trim().length === 0) {
-    throw new Error('Sender email cannot be null or empty string');
-  }
-  if (!sender.name && sender.name.trim().length === 0) {
-    throw new Error('Sender name cannot be empty string');
-  }
-};
-
-const validateEmailContent = (content: EmailContent) => {
-  if (!content) {
-    throw new Error('Content cannot be null');
-  }
-  if (!content.type || content.type.trim().length === 0) {
-    throw new Error('Content type cannot be null or empty string');
-  }
-  if (!content.value || content.value.trim().length === 0) {
-    throw new Error('Content value cannot be null or empty string');
-  }
-};

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -1,1 +1,3 @@
-export default class JunoError extends Error { }
+export class JunoError extends Error { }
+
+export class JunoValidationError extends JunoError { }

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -1,0 +1,1 @@
+export default class JunoError extends Error { }

--- a/src/lib/juno.ts
+++ b/src/lib/juno.ts
@@ -1,6 +1,6 @@
 import { AuthAPI } from './auth';
 import { EmailAPI } from './email';
-import JunoError from './errors';
+import { JunoValidationError } from './errors';
 import { ProjectAPI } from './project';
 import { UserAPI } from './user';
 
@@ -13,21 +13,21 @@ class JunoAPI {
 
   get user(): UserAPI {
     if (!this.userAPI) {
-      throw new JunoError('juno.init() must be called before using the Juno SDK');
+      throw new JunoValidationError('juno.init() must be called before using the Juno SDK');
     }
     return this.userAPI;
   }
 
   get email(): EmailAPI {
     if (!this.emailAPI) {
-      throw new JunoError('juno.init() must be called before using the Juno SDK');
+      throw new JunoValidationError('juno.init() must be called before using the Juno SDK');
     }
     return this.emailAPI;
   }
 
   get project(): ProjectAPI {
     if (!this.projectAPI) {
-      throw new JunoError('juno.init() must be called before using the Juno SDK');
+      throw new JunoValidationError('juno.init() must be called before using the Juno SDK');
     }
     return this.projectAPI;
   }

--- a/src/lib/juno.ts
+++ b/src/lib/juno.ts
@@ -1,5 +1,6 @@
 import { AuthAPI } from './auth';
 import { EmailAPI } from './email';
+import JunoError from './errors';
 import { ProjectAPI } from './project';
 import { UserAPI } from './user';
 
@@ -12,21 +13,21 @@ class JunoAPI {
 
   get user(): UserAPI {
     if (!this.userAPI) {
-      throw new Error('juno.init() must be called before using the Juno SDK');
+      throw new JunoError('juno.init() must be called before using the Juno SDK');
     }
     return this.userAPI;
   }
 
   get email(): EmailAPI {
     if (!this.emailAPI) {
-      throw new Error('juno.init() must be called before using the Juno SDK');
+      throw new JunoError('juno.init() must be called before using the Juno SDK');
     }
     return this.emailAPI;
   }
 
   get project(): ProjectAPI {
     if (!this.projectAPI) {
-      throw new Error('juno.init() must be called before using the Juno SDK');
+      throw new JunoError('juno.init() must be called before using the Juno SDK');
     }
     return this.projectAPI;
   }

--- a/src/lib/project.ts
+++ b/src/lib/project.ts
@@ -4,7 +4,7 @@ import {
   ProjectApi,
   ProjectResponse,
 } from '../internal/api';
-import JunoError from './errors';
+import { JunoValidationError } from './errors';
 import { validateString } from './validators';
 
 // syntax error if name and both id are provided, only either or can be provided
@@ -46,7 +46,7 @@ export class ProjectAPI {
       );
       return res.body;
     } catch (e) {
-      throw new JunoError(e);
+      throw e;
     }
   }
   // Should be by ID or Name
@@ -59,7 +59,7 @@ export class ProjectAPI {
         : await this.internalApi.projectControllerGetProjectByName(input.name);
       return res.body;
     } catch (e) {
-      throw new JunoError(e);
+      throw e;
     }
   }
   // Should be by ID or Name
@@ -77,7 +77,7 @@ export class ProjectAPI {
       !id ||
       id.toString().length === 0
     ) {
-      throw new JunoError(
+      throw new JunoValidationError(
         'Please verify the email is non empty and the id is non empty!'
       );
     }
@@ -98,14 +98,14 @@ export class ProjectAPI {
         );
       return res.body;
     } catch (e) {
-      throw new JunoError(e);
+      throw e;
     }
   }
 }
 
 const checkInput = (input: projectInputType) => {
   if (!input) {
-    throw new JunoError(
+    throw new JunoValidationError(
       'The project input provided must include either the id or name and cannot be null!'
     );
   }
@@ -113,6 +113,6 @@ const checkInput = (input: projectInputType) => {
   validateString(input.name, "The project input name cannot be empty!");
 
   if (!input.id) {
-    throw new JunoError('The project input id cannot be empty!');
+    throw new JunoValidationError('The project input id cannot be empty!');
   }
 };

--- a/src/lib/user.ts
+++ b/src/lib/user.ts
@@ -5,7 +5,7 @@ import {
   CreateUserModel,
   UserResponse,
 } from '../internal/api';
-import JunoError from './errors';
+import { JunoValidationError } from './errors';
 import { validateString } from './validators';
 
 export class UserAPI {
@@ -59,7 +59,7 @@ export class UserAPI {
     validateString(password, "The password must be a non-empty string.");
 
     if (!projectId) {
-      throw new JunoError('The project ID information must be valid.');
+      throw new JunoValidationError('The project ID information must be valid.');
     }
 
     const linkProjectModel: LinkProjectModel = {

--- a/src/lib/user.ts
+++ b/src/lib/user.ts
@@ -5,6 +5,8 @@ import {
   CreateUserModel,
   UserResponse,
 } from '../internal/api';
+import JunoError from './errors';
+import { validateString } from './validators';
 
 export class UserAPI {
   private internalApi: UserApi;
@@ -19,15 +21,13 @@ export class UserAPI {
     adminPassword: string;
   }): Promise<UserResponse> {
     let { email, name, password, adminEmail, adminPassword } = options;
-    if (!email || email.trim().length === 0) {
-      throw new Error('The email must be nonempty');
-    }
-    if (!name || name.trim().length === 0) {
-      throw new Error('The name for the user must be nonempty');
-    }
-    if (!password || password.trim().length === 0) {
-      throw new Error('The password for the user must be nonempty');
-    }
+
+    validateString(email, "The email must be nonempty");
+    validateString(name, "The name must be nonempty");
+    validateString(password, "The password must be nonempty");
+    validateString(adminEmail, "The admin email must be nonempty");
+    validateString(adminPassword, "The admin password must be nonempty");
+
     email = email.trim();
     name = name.trim();
     password = password.trim();
@@ -52,15 +52,16 @@ export class UserAPI {
     password: string;
   }): Promise<UserResponse> {
     let { userId, projectId, projectName, email, password } = options;
-    if (!userId || userId.trim().length === 0) {
-      throw new Error('The user ID must be a non-empty string.');
-    }
+
+    validateString(userId, "The user ID must be a non-empty string.");
+    validateString(projectName, "The project name must be a non-empty string.");
+    validateString(email, "The email must be a non-empty string.");
+    validateString(password, "The password must be a non-empty string.");
+
     if (!projectId) {
-      throw new Error('The project ID information must be valid.');
+      throw new JunoError('The project ID information must be valid.');
     }
-    if (!projectName || projectName.trim().length === 0) {
-      throw new Error('The project name must be a non-empty string.');
-    }
+
     const linkProjectModel: LinkProjectModel = {
       id: projectId,
       name: projectName.trim(),
@@ -79,6 +80,7 @@ export class UserAPI {
       throw e;
     }
   }
+
   async setUserType(options: {
     email: string;
     type: number;
@@ -86,9 +88,8 @@ export class UserAPI {
     adminPassword: string;
   }): Promise<UserResponse> {
     const { email, type, adminEmail, adminPassword } = options;
-    if (!email || email.trim().length === 0) {
-      throw new Error('The email must be a non-empty string.');
-    }
+
+    validateString(email, "The email must be a non-empty string.");
 
     const setUserTypeModel: SetUserTypeModel = {
       email: email.trim(),
@@ -107,9 +108,8 @@ export class UserAPI {
     }
   }
   async getUser(id: string): Promise<UserResponse> {
-    if (!id || id.trim()) {
-      throw new Error('The id must be nonempty');
-    }
+    validateString(id, "The id must be nonempty");
+
     try {
       const res = await this.internalApi.userControllerGetUserById(id);
       return res.body;

--- a/src/lib/validators.ts
+++ b/src/lib/validators.ts
@@ -1,37 +1,35 @@
 import { EmailContent, EmailRecipient, EmailSender } from "../internal/api";
-import JunoError from "./errors";
+import { JunoValidationError } from "./errors";
 
 export const validateString = (str?: String, errorMessage = "Invalid string argument") => {
   if (!str || str.trim().length === 0) {
-    throw new JunoError(errorMessage);
+    throw new JunoValidationError(errorMessage);
   }
 }
 
 export const validateEmailRecipient = (recipient: EmailRecipient) => {
   if (!recipient) {
-    throw new JunoError('Recipient cannot be null');
+    throw new JunoValidationError('Recipient cannot be null');
   }
 
-  validateString(recipient.email);
-  validateString(recipient.name);
+  validateString(recipient.email, "Recipient email cannot be null or empty");
 };
 
 export const validateEmailSender = (sender: EmailSender) => {
   if (!sender) {
-    throw new JunoError('Sender cannot be null');
+    throw new JunoValidationError('Sender cannot be null');
   }
 
-  validateString(sender.email);
-  validateString(sender.name);
+  validateString(sender.email, "Sender email cannot be null or empty");
 };
 
 export const validateEmailContent = (content: EmailContent) => {
   if (!content) {
-    throw new JunoError('Content cannot be null');
+    throw new JunoValidationError('Content cannot be null');
   }
 
-  validateString(content.type);
-  validateString(content.value);
+  validateString(content.type, "Content type cannot be null or empty");
+  validateString(content.value, "Content value cannot be null or empty");
 };
 
 export const validators = {

--- a/src/lib/validators.ts
+++ b/src/lib/validators.ts
@@ -1,0 +1,41 @@
+import { EmailContent, EmailRecipient, EmailSender } from "../internal/api";
+import JunoError from "./errors";
+
+export const validateString = (str?: String, errorMessage = "Invalid string argument") => {
+  if (!str || str.trim().length === 0) {
+    throw new JunoError(errorMessage);
+  }
+}
+
+export const validateEmailRecipient = (recipient: EmailRecipient) => {
+  if (!recipient) {
+    throw new JunoError('Recipient cannot be null');
+  }
+
+  validateString(recipient.email);
+  validateString(recipient.name);
+};
+
+export const validateEmailSender = (sender: EmailSender) => {
+  if (!sender) {
+    throw new JunoError('Sender cannot be null');
+  }
+
+  validateString(sender.email);
+  validateString(sender.name);
+};
+
+export const validateEmailContent = (content: EmailContent) => {
+  if (!content) {
+    throw new JunoError('Content cannot be null');
+  }
+
+  validateString(content.type);
+  validateString(content.value);
+};
+
+export const validators = {
+  validateEmailRecipient,
+  validateEmailSender,
+  validateEmailContent,
+}

--- a/tests/email/emailApi.test.ts
+++ b/tests/email/emailApi.test.ts
@@ -1,6 +1,6 @@
 import { EmailRecipient } from "../../src/internal/api";
 import { EmailAPI } from "../../src/lib/email";
-import { JunoError, JunoValidationError } from "../../src/lib/errors";
+import { JunoValidationError } from "../../src/lib/errors";
 
 describe("sendEmail validation tests", () => {
   it("throws a validation error with a recipient", async () => {

--- a/tests/email/emailApi.test.ts
+++ b/tests/email/emailApi.test.ts
@@ -1,8 +1,9 @@
+import { EmailRecipient } from "../../src/internal/api";
 import { EmailAPI } from "../../src/lib/email";
-import { JunoError } from "../../src/lib/errors";
+import { JunoError, JunoValidationError } from "../../src/lib/errors";
 
-describe("Email validation tests", () => {
-  it("does not throw an validation error with a recipient", async () => {
+describe("sendEmail validation tests", () => {
+  it("throws a validation error with a recipient", async () => {
     let emailApi = new EmailAPI();
 
     await expect(async () => {
@@ -22,8 +23,8 @@ describe("Email validation tests", () => {
         }]
       })
     }).rejects.toThrow(TypeError); // TypeError from lack of apiKey
-  }
-  );
+  });
+
   it("does not throw an validation error with a recipient", async () => {
     let emailApi = new EmailAPI();
 
@@ -46,14 +47,14 @@ describe("Email validation tests", () => {
     }).rejects.toThrow(TypeError); // TypeError from lack of apiKey
   });
 
-  it("does throw an validation error with no recipient, cc, or bcc", async () => {
+  it("does not throw an validation error with a recipient", async () => {
     let emailApi = new EmailAPI();
 
     await expect(async () => {
       await emailApi.sendEmail({
-        recipients: [],
-        cc: [],
-        bcc: [],
+        recipients: [{
+          "email": "somerecipientemail"
+        }],
         sender: {
           "email": "someemail",
         },
@@ -63,7 +64,57 @@ describe("Email validation tests", () => {
           "value": "some value"
         }]
       })
-    }).rejects.toThrow(JunoError); // TypeError from lack of apiKey
+    }).rejects.toThrow(TypeError); // TypeError from lack of apiKey
+  });
+
+  it("throws an validation error with no recipient, cc, or bcc", async () => {
+    let emailApi = new EmailAPI();
+
+    let recipients: unknown = null
+
+    await expect(async () => {
+      await emailApi.sendEmail({
+        recipients: recipients as Array<EmailRecipient>,
+        sender: {
+          "email": "someemail",
+        },
+        subject: "subject",
+        contents: [{
+          "type": "html",
+          "value": "some value"
+        }]
+      })
+    }).rejects.toThrow(JunoValidationError);
+
+    // also with empty array
+    await expect(async () => {
+      await emailApi.sendEmail({
+        recipients: [],
+        sender: {
+          "email": "someemail",
+        },
+        subject: "subject",
+        contents: [{
+          "type": "html",
+          "value": "some value"
+        }]
+      })
+    }).rejects.toThrow(JunoValidationError);
+  });
+
+  it("throws an validation error with an empty content array", async () => {
+    let emailApi = new EmailAPI();
+
+    await expect(async () => {
+      await emailApi.sendEmail({
+        recipients: [{ email: "someemail" }],
+        sender: {
+          "email": "someemail",
+        },
+        subject: "subject",
+        contents: []
+      })
+    }).rejects.toThrow(JunoValidationError);
   });
 
   it("does not throw a validation error with only cc", async () => {
@@ -75,7 +126,6 @@ describe("Email validation tests", () => {
         cc: [{
           "email": "somerecipientemail"
         }],
-        bcc: [],
         sender: {
           "email": "someemail",
         },
@@ -94,7 +144,6 @@ describe("Email validation tests", () => {
     await expect(async () => {
       await emailApi.sendEmail({
         recipients: [],
-        cc: [],
         bcc: [{
           "email": "somerecipientemail"
         }],
@@ -108,5 +157,114 @@ describe("Email validation tests", () => {
         }]
       })
     }).rejects.toThrow(TypeError); // TypeError from lack of apiKey
+  });
+})
+
+describe("Registering sender test validation tests", () => {
+  it("throws a validation error if name is null or blank", async () => {
+    let emailApi = new EmailAPI();
+
+    let name: unknown = null
+
+    await expect(async () => {
+      await emailApi.registerSenderAddress({
+        email: "email",
+        name: name as string,
+        replyTo: "replyto"
+      })
+    }).rejects.toThrow(JunoValidationError);
+
+    name = "      ";
+
+    await expect(async () => {
+      await emailApi.registerSenderAddress({
+        email: "email",
+        name: name as string,
+        replyTo: "replyto"
+      })
+    }).rejects.toThrow(JunoValidationError);
+  });
+
+  it("throws a validation error if email is null or blank", async () => {
+    let emailApi = new EmailAPI();
+
+    let email: unknown = null
+
+    await expect(async () => {
+      await emailApi.registerSenderAddress({
+        email: email as string,
+        name: "name",
+        replyTo: "replyto"
+      })
+    }).rejects.toThrow(JunoValidationError);
+
+    email = "      ";
+
+    await expect(async () => {
+      await emailApi.registerSenderAddress({
+        email: email as string,
+        name: "name",
+        replyTo: "replyto"
+      })
+    }).rejects.toThrow(JunoValidationError);
+  });
+
+
+  it("does not throw a validation error if email and name are valid", async () => {
+    let emailApi = new EmailAPI();
+
+    await expect(async () => {
+      await emailApi.registerSenderAddress({
+        email: "email",
+        name: "name",
+        replyTo: "replyto"
+      })
+    }).rejects.toThrow(TypeError); // TypeError from lack of apiKey
+  });
+})
+
+describe("register domain validation tests", () => {
+  it("throws a validation error if domain is null or blank", async () => {
+    let emailApi = new EmailAPI();
+
+    let domain: unknown = null
+
+    await expect(async () => {
+      await emailApi.registerDomain({
+        domain: domain as string,
+        subdomain: undefined
+      })
+    }).rejects.toThrow(JunoValidationError);
+
+    domain = "      ";
+
+    await expect(async () => {
+      await emailApi.registerDomain({
+        domain: domain as string,
+        subdomain: undefined
+      })
+    }).rejects.toThrow(JunoValidationError);
+  });
+})
+
+describe("verify domain validation tests", () => {
+  it("throws a validation error if domain is null or blank", async () => {
+    let emailApi = new EmailAPI();
+
+    let domain: unknown = null
+
+    await expect(async () => {
+      await emailApi.verifyDomain({
+        domain: domain as string,
+      })
+    }).rejects.toThrow(JunoValidationError);
+
+    domain = "      ";
+
+    await expect(async () => {
+      await emailApi.verifyDomain({
+        domain: domain as string,
+      })
+    }).rejects.toThrow(JunoValidationError);
   });
 })

--- a/tests/email/emailApi.test.ts
+++ b/tests/email/emailApi.test.ts
@@ -1,0 +1,112 @@
+import { EmailAPI } from "../../src/lib/email";
+import { JunoError } from "../../src/lib/errors";
+
+describe("Email validation tests", () => {
+  it("does not throw an validation error with a recipient", async () => {
+    let emailApi = new EmailAPI();
+
+    await expect(async () => {
+      await emailApi.sendEmail({
+        recipients: [{
+          "email": "somerecipientemail"
+        }],
+        cc: [],
+        bcc: [],
+        sender: {
+          "email": "someemail",
+        },
+        subject: "subject",
+        contents: [{
+          "type": "html",
+          "value": "some value"
+        }]
+      })
+    }).rejects.toThrow(TypeError); // TypeError from lack of apiKey
+  }
+  );
+  it("does not throw an validation error with a recipient", async () => {
+    let emailApi = new EmailAPI();
+
+    await expect(async () => {
+      await emailApi.sendEmail({
+        recipients: [{
+          "email": "somerecipientemail"
+        }],
+        cc: [],
+        bcc: [],
+        sender: {
+          "email": "someemail",
+        },
+        subject: "subject",
+        contents: [{
+          "type": "html",
+          "value": "some value"
+        }]
+      })
+    }).rejects.toThrow(TypeError); // TypeError from lack of apiKey
+  });
+
+  it("does throw an validation error with no recipient, cc, or bcc", async () => {
+    let emailApi = new EmailAPI();
+
+    await expect(async () => {
+      await emailApi.sendEmail({
+        recipients: [],
+        cc: [],
+        bcc: [],
+        sender: {
+          "email": "someemail",
+        },
+        subject: "subject",
+        contents: [{
+          "type": "html",
+          "value": "some value"
+        }]
+      })
+    }).rejects.toThrow(JunoError); // TypeError from lack of apiKey
+  });
+
+  it("does not throw a validation error with only cc", async () => {
+    let emailApi = new EmailAPI();
+
+    await expect(async () => {
+      await emailApi.sendEmail({
+        recipients: [],
+        cc: [{
+          "email": "somerecipientemail"
+        }],
+        bcc: [],
+        sender: {
+          "email": "someemail",
+        },
+        subject: "subject",
+        contents: [{
+          "type": "html",
+          "value": "some value"
+        }]
+      })
+    }).rejects.toThrow(TypeError); // TypeError from lack of apiKey
+  });
+
+  it("does not throw a validation error with only bcc", async () => {
+    let emailApi = new EmailAPI();
+
+    await expect(async () => {
+      await emailApi.sendEmail({
+        recipients: [],
+        cc: [],
+        bcc: [{
+          "email": "somerecipientemail"
+        }],
+        sender: {
+          "email": "someemail",
+        },
+        subject: "subject",
+        contents: [{
+          "type": "html",
+          "value": "some value"
+        }]
+      })
+    }).rejects.toThrow(TypeError); // TypeError from lack of apiKey
+  });
+})

--- a/tests/validators/validators.test.ts
+++ b/tests/validators/validators.test.ts
@@ -1,0 +1,98 @@
+import { EmailApi } from "../../src/internal/api";
+import { EmailRecipient } from "../../src/internal/model/emailRecipient";
+import JunoError from "../../src/lib/errors";
+import { validateEmailRecipient, validateString } from "../../src/lib/validators";
+
+describe("Email validation tests", () => {
+  it("throws an error if a recipient is null", () => {
+    let validEmailRecipient: unknown = null;
+
+    expect(() => {
+      validateEmailRecipient(validEmailRecipient as EmailRecipient);
+    }).toThrow(JunoError);
+  });
+
+  it("throws an error if a recipient email is null", () => {
+    let validEmailRecipient: unknown = {};
+
+    expect(() => {
+      validateEmailRecipient(validEmailRecipient as EmailRecipient);
+    }).toThrow(JunoError);
+
+    validEmailRecipient = {
+      email: null
+    }
+
+    expect(() => {
+      validateEmailRecipient(validEmailRecipient as EmailRecipient);
+    }).toThrow(JunoError);
+  });
+
+
+  it("throws an error if a recipient email is blank", () => {
+    let validEmailRecipient: unknown = {
+      email: "     "
+    };
+
+    expect(() => {
+      validateEmailRecipient(validEmailRecipient as EmailRecipient);
+    }).toThrow(JunoError);
+  });
+
+  it("throws an error if a recipient name is null", () => {
+    let validEmailRecipient: unknown = {
+      email: "someEmail"
+    };
+
+    expect(() => {
+      validateEmailRecipient(validEmailRecipient as EmailRecipient);
+    }).toThrow(JunoError);
+
+    validEmailRecipient = {
+      email: "someEmail",
+      name: null
+    };
+
+    expect(() => {
+      validateEmailRecipient(validEmailRecipient as EmailRecipient);
+    }).toThrow(JunoError);
+  });
+
+  it("throws an error if a recipient name is blank", () => {
+    let validEmailRecipient: unknown = {
+      email: "someEmail",
+      name: "    "
+    };
+
+    expect(() => {
+      validateEmailRecipient(validEmailRecipient as EmailRecipient);
+    }).toThrow(JunoError);
+  });
+
+});
+
+
+describe("String validation tests", () => {
+  it("throws an error if the string is empty or null", () => {
+    let str = "";
+
+    expect(() => {
+      validateString(str)
+    }).toThrow(JunoError);
+
+
+    let nullStr: unknown = null;
+
+    expect(() => {
+      validateString(nullStr as string)
+    }).toThrow(JunoError);
+  })
+
+  it("throws an error if the string is blank", () => {
+    let str = "      ";
+
+    expect(() => {
+      validateString(str)
+    }).toThrow(JunoError);
+  })
+});

--- a/tests/validators/validators.test.ts
+++ b/tests/validators/validators.test.ts
@@ -1,6 +1,5 @@
-import { EmailApi } from "../../src/internal/api";
 import { EmailRecipient } from "../../src/internal/model/emailRecipient";
-import JunoError from "../../src/lib/errors";
+import { JunoError } from "../../src/lib/errors";
 import { validateEmailRecipient, validateString } from "../../src/lib/validators";
 
 describe("Email validation tests", () => {
@@ -39,34 +38,21 @@ describe("Email validation tests", () => {
     }).toThrow(JunoError);
   });
 
-  it("throws an error if a recipient name is null", () => {
+  it("does not throw an error if a recipient name is null", () => {
     let validEmailRecipient: unknown = {
       email: "someEmail"
     };
 
-    expect(() => {
-      validateEmailRecipient(validEmailRecipient as EmailRecipient);
-    }).toThrow(JunoError);
-
-    validEmailRecipient = {
-      email: "someEmail",
-      name: null
-    };
-
-    expect(() => {
-      validateEmailRecipient(validEmailRecipient as EmailRecipient);
-    }).toThrow(JunoError);
+    validateEmailRecipient(validEmailRecipient as EmailRecipient);
   });
 
-  it("throws an error if a recipient name is blank", () => {
+  it("does not throw an error if a recipient name is blank", () => {
     let validEmailRecipient: unknown = {
       email: "someEmail",
       name: "    "
     };
 
-    expect(() => {
-      validateEmailRecipient(validEmailRecipient as EmailRecipient);
-    }).toThrow(JunoError);
+    validateEmailRecipient(validEmailRecipient as EmailRecipient);
   });
 
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -35,7 +35,8 @@
       "es2017"
     ],
     "types": [
-      "node"
+      "node",
+      "jest"
     ],
     "typeRoots": [
       "node_modules/@types",
@@ -43,7 +44,8 @@
     ]
   },
   "include": [
-    "src/**/*.ts"
+    "src/**/*.ts",
+    "tests/**/*.ts"
   ],
   "exclude": [
     "node_modules/**"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -44,11 +44,11 @@
     ]
   },
   "include": [
-    "src/**/*.ts",
-    "tests/**/*.ts"
+    "src/**/*.ts"
   ],
   "exclude": [
-    "node_modules/**"
+    "node_modules/**",
+    "tests/**/*"
   ],
   "compileOnSave": false
 }


### PR DESCRIPTION
- Added full validation test coverage of EmailAPI-related methods
- Moved all Error throws to JunoError to be more easily detected with unit tests
- Fixed bug where an undefined email sender resulted in an undefined error 
- Refactored all validations to now use a centralized validation system to reduce chance of error
- Added unit tests for string and email validation, with reproduction of aforementioned bug 
- Added jest to the project
- Juno imports no longer require `build/main` in the name 