### PR TITLE
Add replyToList, optional recipients

### DIFF
--- a/src/internal/model/sendEmailModel.ts
+++ b/src/internal/model/sendEmailModel.ts
@@ -29,6 +29,10 @@ export class SendEmailModel {
     */
     'bcc': Array<EmailRecipient>;
     /**
+    * List of emails to add to the Reply To list of the email
+    */
+    'replyToList': Array<EmailRecipient>;
+    /**
     * The sender of the email
     */
     'sender': EmailSender;
@@ -57,6 +61,11 @@ export class SendEmailModel {
         {
             "name": "bcc",
             "baseName": "bcc",
+            "type": "Array<EmailRecipient>"
+        },
+        {
+            "name": "replyToList",
+            "baseName": "replyToList",
             "type": "Array<EmailRecipient>"
         },
         {

--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -24,15 +24,16 @@ export class EmailAPI {
     this.internalApi.accessToken = this.auth?.junoApiKey;
   }
   async sendEmail(options: {
-    recipients: Array<EmailRecipient>;
+    recipients?: Array<EmailRecipient>;
     cc?: Array<EmailRecipient>;
     bcc?: Array<EmailRecipient>;
+    replyToList?: Array<EmailRecipient>;
     sender: EmailSender;
     subject: string;
     contents: Array<EmailContent>;
   }): Promise<SendEmailResponse> {
-    const { recipients, cc, bcc, sender, contents } = options;
-    if (!recipients || !sender || !contents) {
+    const { recipients, cc, bcc, sender, contents, replyToList } = options;
+    if (!sender || !contents) {
       throw new JunoValidationError(
         'Parameter recipients or sender or content cannot be null'
       );
@@ -53,9 +54,10 @@ export class EmailAPI {
 
     try {
       const sendEmailModel = new SendEmailModel();
-      sendEmailModel.recipients = recipients;
       sendEmailModel.sender = sender;
       sendEmailModel.content = contents;
+      sendEmailModel.recipients = recipients ?? [];
+      sendEmailModel.replyToList = replyToList ?? [];
       sendEmailModel.cc = cc ?? [];
       sendEmailModel.bcc = bcc ?? [];
       sendEmailModel.subject = options.subject;

--- a/tests/email/emailApi.test.ts
+++ b/tests/email/emailApi.test.ts
@@ -74,7 +74,6 @@ describe("sendEmail validation tests", () => {
 
     await expect(async () => {
       await emailApi.sendEmail({
-        recipients: recipients as Array<EmailRecipient>,
         sender: {
           "email": "someemail",
         },
@@ -89,7 +88,6 @@ describe("sendEmail validation tests", () => {
     // also with empty array
     await expect(async () => {
       await emailApi.sendEmail({
-        recipients: [],
         sender: {
           "email": "someemail",
         },
@@ -122,7 +120,6 @@ describe("sendEmail validation tests", () => {
 
     await expect(async () => {
       await emailApi.sendEmail({
-        recipients: [],
         cc: [{
           "email": "somerecipientemail"
         }],
@@ -143,7 +140,6 @@ describe("sendEmail validation tests", () => {
 
     await expect(async () => {
       await emailApi.sendEmail({
-        recipients: [],
         bcc: [{
           "email": "somerecipientemail"
         }],


### PR DESCRIPTION
- Fixed bug where although recipients was optional, the validation required a non-empty list
- Added replyToList functionality (see https://www.twilio.com/docs/sendgrid/api-reference/mail-send/mail-send)