### PR TITLE
Add Settings API to SDK

### DIFF
--- a/src/lib/juno.ts
+++ b/src/lib/juno.ts
@@ -2,6 +2,7 @@ import { AuthAPI } from './auth';
 import { EmailAPI } from './email';
 import { JunoValidationError } from './errors';
 import { ProjectAPI } from './project';
+import { SettingsAPI } from './settings';
 import { UserAPI } from './user';
 
 class JunoAPI {
@@ -10,6 +11,7 @@ class JunoAPI {
   private emailAPI?: EmailAPI;
   private projectAPI?: ProjectAPI;
   private authAPI?: AuthAPI;
+  private settingsAPI?: SettingsAPI;
 
   get user(): UserAPI {
     if (!this.userAPI) {
@@ -18,6 +20,15 @@ class JunoAPI {
       );
     }
     return this.userAPI;
+  }
+
+  get settings(): SettingsAPI {
+    if (!this.settingsAPI) {
+      throw new JunoValidationError(
+        'juno.init() must be called before using the Juno SDK'
+      );
+    }
+    return this.settingsAPI;
   }
 
   get email(): EmailAPI {
@@ -52,6 +63,7 @@ class JunoAPI {
     this.userAPI = new UserAPI(options.baseURL);
     this.emailAPI = new EmailAPI(options.baseURL, this.authAPI);
     this.projectAPI = new ProjectAPI(options.baseURL, this.apiKey);
+    this.settingsAPI = new SettingsAPI(options.baseURL, this.apiKey);
   }
 }
 

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -1,0 +1,33 @@
+import {
+  EmailApi,
+  EmailConfigResponse,
+  FileConfigApi,
+  FileConfigResponse,
+} from '../internal/api';
+
+export class SettingsAPI {
+  private internalFileConfigApi: FileConfigApi;
+  private internalEmailApi: EmailApi;
+  constructor(baseURL?: string, apiKey?: string) {
+    this.internalFileConfigApi = new FileConfigApi(baseURL);
+    this.internalFileConfigApi.accessToken = apiKey;
+
+    this.internalEmailApi = new EmailApi(baseURL);
+    this.internalEmailApi.accessToken = apiKey;
+  }
+
+  async getFileConfig(projectId: string): Promise<FileConfigResponse> {
+    const res =
+      await this.internalFileConfigApi.fileConfigControllerGetFileConfigByProjectId(
+        projectId
+      );
+    return res.body;
+  }
+
+  async getEmailConfig(projectId: string): Promise<EmailConfigResponse> {
+    const res = await this.internalEmailApi.emailControllerGetEmailConfigById(
+      projectId
+    );
+    return res.body;
+  }
+}


### PR DESCRIPTION
# Add Settings API to SDK
## File Config:
- Missing File objects from juno proto: `'files': Array<any>;` in `FileConfigResponse`
- Missing File objects from juno proto: `'fileServiceFile': Array<object>;` in `FileBucket`
## Email Config:
- Missing Project objects from juno proto: `''projects': Array<object>;` in `EmailDomain`
- Missing Project objects from juno proto: `''projects': Array<object>;` in `EmailSender`